### PR TITLE
Basic connection to IPFS daemon

### DIFF
--- a/src/main/ipfs/classes.ts
+++ b/src/main/ipfs/classes.ts
@@ -1,6 +1,8 @@
-export enum DaemonRequest {
+enum DaemonRequest {
     ADD,
     DELETE,
     GET,
     PING
 }
+
+export default DaemonRequest;

--- a/src/main/ipfs/classes.ts
+++ b/src/main/ipfs/classes.ts
@@ -1,0 +1,6 @@
+export enum DaemonRequest {
+    ADD,
+    DELETE,
+    GET,
+    PING
+}

--- a/src/main/ipfs/classes.ts
+++ b/src/main/ipfs/classes.ts
@@ -1,8 +1,8 @@
 enum DaemonRequest {
-    ADD,
-    DELETE,
-    GET,
-    PING
+  ADD,
+  DELETE,
+  GET,
+  PING,
 }
 
 export default DaemonRequest;

--- a/src/main/ipfs/ipfs.ts
+++ b/src/main/ipfs/ipfs.ts
@@ -4,117 +4,105 @@ import Request from './request_json';
 import Response from './response_json';
 import DaemonRequest from './classes';
 
-class IPFS {
-  HOST: string = 'localhost';
+const HOST = 'localhost';
+const PORT = 7777;
 
-  PORT: number = 7777;
+const createClient = (reject: (reason?: Error) => void): net.Socket => {
+  const client = new net.Socket();
 
-  client: net.Socket;
+  client.on('error', (err) => {
+    reject(err);
+  });
 
-  constructor() {
-    this.client = new net.Socket();
-    this.init();
-  }
+  client.connect(PORT, HOST, () => {
+    // console.log(`Connected to daemon (${this.HOST}:${this.PORT})`);
+  });
 
-  private init() {
-    this.client.connect(this.PORT, this.HOST, () => {
-      // console.log(`Connected to daemon (${this.HOST}:${this.PORT})`);
-    });
+  client.on('end', () => {
+    // console.log('Disconnected from daemon');
+  });
+  return client;
+};
 
-    this.client.on('end', () => {
-      // console.log('Disconnected from daemon');
-    });
-  }
+const parseResponse = (data: Buffer) => {
+  const dataStr: string = data.toString();
+  return new Response().deserialize(dataStr);
+};
 
-  /*
-   * Manually exit the connection with the daemon.
-   */
-  exit() {
-    this.client.end();
-  }
+/*
+ * ping the daemon. Mainly used for testing or verifying that the daemon is
+ * running. Returns whether the ping was correctly received.
+ */
+export function pingIPFS() {
+  return new Promise((resolve, reject) => {
+    const client = createClient(reject);
 
-  /*
-   * ping the daemon. Mainly used for testing or verifying that the daemon is
-   * running. Returns whether the ping was correctly received.
-   */
-  ping() {
-    return new Promise((resolve, reject) => {
-      const request = new Request();
-      request.Class = DaemonRequest.PING;
+    const request = new Request();
+    request.Class = DaemonRequest.PING;
 
-      if (!this.client.write(request.serialize())) {
-        reject(new Error('Failed to write request to TCP connection'));
+    if (!client.write(request.serialize())) {
+      reject(new Error('Failed to send request to daemon'));
+    }
+
+    client.on('data', (data) => {
+      const response = parseResponse(data);
+      if (response.Msg === 'Pong') {
+        resolve(true);
+      } else {
+        reject(
+          new Error(`Received response '${response.Msg}' and note 'Pong'`)
+        );
       }
-
-      this.client.on('data', (data) => {
-        const response = this.parseResponse(data);
-        if (response.Msg === 'Pong') {
-          resolve(true);
-        } else {
-          reject(
-            new Error(`Received response '${response.Msg}' and not 'Pong'`)
-          );
-        }
-      });
-
-      this.client.on('error', (err) => {
-        reject(err);
-      });
     });
-  }
 
-  /*
-   * add a file or directory to IPFS. The string returned on success is the
-   * CID of the added content.
-   */
-  add(path: string) {
-    return new Promise((resolve, reject) => {
-      const request = new Request();
-      request.Class = DaemonRequest.ADD;
-      request.Path = path;
-
-      if (!this.client.write(request.serialize())) {
-        reject(new Error('Failed to write request to TCP connection'));
-      }
-
-      this.client.on('data', (data) => {
-        resolve(this.parseResponse(data).Msg);
-      });
-
-      this.client.on('error', (err) => {
-        reject(err);
-      });
+    client.on('error', (err) => {
+      reject(err);
     });
-  }
+  });
+}
 
-  /*
-   * Get a piece of content from IPFS. Given the CID to fetch and the path to
-   * the directory to save the content into, the daemon will interact with
-   * IPFS and download as needed. Returned will be the path to the content
-   */
-  get(cid: string, path: string) {
-    return new Promise((resolve, reject) => {
-      const request = new Request();
-      request.Class = DaemonRequest.GET;
-      request.Cid = cid;
-      request.Path = path;
+/*
+ * add a file or directory to IPFS. The string returned on success is the CID
+ * of the added content.
+ */
+export function addIPFS(path: string) {
+  return new Promise((resolve, reject) => {
+    const client = createClient(reject);
 
-      if (!this.client.write(request.serialize())) {
-        reject(new Error('Failed to write request to TCP connection'));
-      }
+    const request = new Request();
+    request.Class = DaemonRequest.ADD;
+    request.Path = path;
 
-      this.client.on('data', (data) => {
-        resolve(this.parseResponse(data).Msg);
-      });
+    if (!client.write(request.serialize())) {
+      reject(new Error('Failed to send request to daemon'));
+    }
 
-      this.client.on('error', (err) => {
-        reject(err);
-      });
+    client.on('data', (data) => {
+      resolve(parseResponse(data).Msg);
     });
-  }
+  });
+}
 
-  parseResponse = (data: Buffer) => {
-    const dataStr: string = data.toString();
-    return new Response().deserialize(dataStr);
-  };
+/*
+ * Get a piece of content from IPFS. Given the CID to fetch and the path to
+ * the directory to save the content into, the daemon will interact with
+ * IPFS and download as needed. Returned will be the path to the content
+ */
+export function getIPFS(cid: string, path: string) {
+  return new Promise((resolve, reject) => {
+    const client = createClient(reject);
+
+    const request = new Request();
+    request.Class = DaemonRequest.GET;
+    request.Cid = cid;
+    request.Path = path;
+
+    if (!client.write(request.serialize())) {
+      reject(new Error('Failed to send request to daemon'));
+    }
+
+    client.on('data', (data) => {
+      resolve(parseResponse(data).Msg);
+    });
+  });
 }

--- a/src/main/ipfs/ipfs.ts
+++ b/src/main/ipfs/ipfs.ts
@@ -4,17 +4,25 @@ import Request from './request_json';
 import Response from './response_json';
 import DaemonRequest from './classes';
 
-const HOST = 'localhost';
-const PORT = 7777;
+const DEFAULT_HOST = 'localhost';
+const DEFAULT_PORT = 7777;
 
-const createClient = (reject: (reason?: Error) => void): net.Socket => {
+/*
+ * Creates a client connection to the server and defines how to respond when
+ * this connection exits. Connected socket is returned
+ */
+const createClient = (
+  port: number,
+  host: string,
+  reject: (reason?: Error) => void
+): net.Socket => {
   const client = new net.Socket();
 
   client.on('error', (err) => {
     reject(err);
   });
 
-  client.connect(PORT, HOST, () => {
+  client.connect(port, host, () => {
     // console.log(`Connected to daemon (${this.HOST}:${this.PORT})`);
   });
 
@@ -24,6 +32,22 @@ const createClient = (reject: (reason?: Error) => void): net.Socket => {
   return client;
 };
 
+/*
+ *
+ */
+const issueRequest = (
+  client: net.Socket,
+  request: Request,
+  reject: (reason?: Error) => void
+) => {
+  if (!client.write(request.serialize())) {
+    reject(new Error('Failed to send request to daemon'));
+  }
+};
+
+/*
+ * Parses a response from the server into a typescript response structure
+ */
 const parseResponse = (data: Buffer) => {
   const dataStr: string = data.toString();
   return new Response().deserialize(dataStr);
@@ -33,16 +57,13 @@ const parseResponse = (data: Buffer) => {
  * ping the daemon. Mainly used for testing or verifying that the daemon is
  * running. Returns whether the ping was correctly received.
  */
-export function pingIPFS() {
+export function pingIPFS(port = DEFAULT_PORT, host = DEFAULT_HOST) {
   return new Promise((resolve, reject) => {
-    const client = createClient(reject);
+    const client = createClient(port, host, reject);
 
     const request = new Request();
     request.Class = DaemonRequest.PING;
-
-    if (!client.write(request.serialize())) {
-      reject(new Error('Failed to send request to daemon'));
-    }
+    issueRequest(client, request, reject);
 
     client.on('data', (data) => {
       const response = parseResponse(data);
@@ -54,10 +75,6 @@ export function pingIPFS() {
         );
       }
     });
-
-    client.on('error', (err) => {
-      reject(err);
-    });
   });
 }
 
@@ -65,17 +82,18 @@ export function pingIPFS() {
  * add a file or directory to IPFS. The string returned on success is the CID
  * of the added content.
  */
-export function addIPFS(path: string) {
+export function addIPFS(
+  path: string,
+  port = DEFAULT_PORT,
+  host = DEFAULT_HOST
+) {
   return new Promise((resolve, reject) => {
-    const client = createClient(reject);
+    const client = createClient(port, host, reject);
 
     const request = new Request();
     request.Class = DaemonRequest.ADD;
     request.Path = path;
-
-    if (!client.write(request.serialize())) {
-      reject(new Error('Failed to send request to daemon'));
-    }
+    issueRequest(client, request, reject);
 
     client.on('data', (data) => {
       resolve(parseResponse(data).Msg);
@@ -88,18 +106,20 @@ export function addIPFS(path: string) {
  * the directory to save the content into, the daemon will interact with
  * IPFS and download as needed. Returned will be the path to the content
  */
-export function getIPFS(cid: string, path: string) {
+export function getIPFS(
+  cid: string,
+  path: string,
+  port = DEFAULT_PORT,
+  host = DEFAULT_HOST
+) {
   return new Promise((resolve, reject) => {
-    const client = createClient(reject);
+    const client = createClient(port, host, reject);
 
     const request = new Request();
     request.Class = DaemonRequest.GET;
     request.Cid = cid;
     request.Path = path;
-
-    if (!client.write(request.serialize())) {
-      reject(new Error('Failed to send request to daemon'));
-    }
+    issueRequest(client, request, reject);
 
     client.on('data', (data) => {
       resolve(parseResponse(data).Msg);

--- a/src/main/ipfs/ipfs.ts
+++ b/src/main/ipfs/ipfs.ts
@@ -1,133 +1,117 @@
-import { Request } from "./request_json"
-import { Response } from "./response_json";
 import * as net from 'net'
-import { DaemonRequest } from "./classes";
+
+import Request from './request_json'
+import Response from './response_json';
+import DaemonRequest from './classes';
 
 class IPFS {
-    HOST: string = 'localhost';
-    PORT: number = 7777;
-    
-    client: net.Socket;
+  HOST: string = 'localhost';
+  PORT: number = 7777;
+  client: net.Socket;
 
-    constructor() {
-        this.client = new net.Socket();
-        this.init();
-    }
+  constructor() {
+    this.client = new net.Socket();
+    this.init();
+  }
 
-    private init() {
-        this.client.connect(this.PORT, this.HOST, () => {
-            console.log(`Connected to daemon (${this.HOST}:${this.PORT})`);
-        })
+  private init() {
+    this.client.connect(this.PORT, this.HOST, () => {
+      console.log(`Connected to daemon (${this.HOST}:${this.PORT})`);
+    });
 
-        this.client.on('end', () => {
-            console.log("Disconnected from daemon");
-        })
-    }
+    this.client.on('end', () => { console.log("Disconnected from daemon"); });
+  }
 
-    /*
-     * Manually exit the connection with the daemon.
-     */
-    exit() {
-        this.client.end();
-    }
+  /*
+    * Manually exit the connection with the daemon.
+    */
+  exit() {
+    this.client.end();
+  }
 
-    /*
-     * ping the daemon. Mainly used for testing or verifying that the daemon is
-     * running. Returns whether the ping was correctly received.
-     */
-    ping() {
-        return new Promise((resolve, reject) => {
-            var request   = new Request;
-            request.Class = DaemonRequest.PING;
-    
-            if (! this.client.write(request.serialize())) {
-                console.log("Failed to write request to TCP connection");
-                reject("Failed to write request to TCP connection");
-            }
+  /*
+    * ping the daemon. Mainly used for testing or verifying that the daemon is
+    * running. Returns whether the ping was correctly received.
+    */
+  ping() {
+    return new Promise((resolve, reject) => {
+      let request   = new Request;
+      request.Class = DaemonRequest.PING;
 
-            this.client.on('data', (data) => {
-                var response = this.parseResponse(data);
+      if (! this.client.write(request.serialize())) {
+        console.log("Failed to write request to TCP connection");
+        reject("Failed to write request to TCP connection");
+      }
 
-                console.log(`Class: ${response.Class}`);
-                console.log(`Msg:   ${response.Msg}`);
+      this.client.on('data', (data) => {
+        let response = this.parseResponse(data);
+        if (response.Msg == "Pong") {
+          resolve(true);
+        } else {
+          reject(`Received response '${response.Msg}' and not 'Pong'`);
+        }
+      });
 
-                resolve(true);
-            })
+      this.client.on('error', (err) => {
+        reject(err);
+      })
+    });
+  }
 
-            this.client.on('error', (err) => {
-                console.log(`Error: ${err}`);
-                reject(err);
-            })
-        });
-    }
+  /*
+    * add a file or directory to IPFS. The string returned on success is the
+    * CID of the added content.
+    */
+  add(path: string) {
+    return new Promise((resolve, reject) => {
+      let request   = new Request;
+      request.Class = DaemonRequest.ADD;
+      request.Path  = path;
 
-    /*
-     * add a file or directory to IPFS. The string returned on success is the
-     * CID of the added content.
-     */
-    add(path: string) {
-        return new Promise((resolve, reject) => {
-            var request   = new Request;
-            request.Class = DaemonRequest.ADD;
-            request.Path  = path;
+      if (! this.client.write(request.serialize())) {
+        reject("Failed to write request to TCP connection");
+      }
 
-            if (! this.client.write(request.serialize())) {
-                console.log("Failed to write request to TCP connection");
-                reject("Failed to write request to TCP connection");
-            }
+      this.client.on('data', (data) => {
+        let response = this.parseResponse(data);
+        resolve(response.Msg);
+      });
 
-            this.client.on('data', (data) => {
-                var response = this.parseResponse(data);
-                console.log(`Class: ${response.Class}`);
-                console.log(`Msg:   ${response.Msg}`);
-                resolve(response.Msg);
-                this.exit();
-            });
+      this.client.on('error', (err) => {
+        reject(err);
+      });
+    })
+  }
 
-            this.client.on('error', (err) => {
-                console.log(`Error: ${err}`);
-                reject(err);
-                this.exit();
-            });
-        })
-    }
+  /*
+    * Get a piece of content from IPFS. Given the CID to fetch and the path to
+    * the directory to save the content into, the daemon will interact with
+    * IPFS and download as needed. Returned will be the path to the content
+    */
+  get(cid: string, path: string) {
+    return new Promise((resolve, reject) => {
+      let request   = new Request;
+      request.Class = DaemonRequest.GET;
+      request.Cid   = cid;
+      request.Path  = path;
 
-    /*
-     * Get a piece of content from IPFS. Given the CID to fetch and the path to
-     * the directory to save the content into, the daemon will interact with
-     * IPFS and download as needed. Returned will be the path to the content
-     */
-    get(cid: string, path: string) {
-        return new Promise((resolve, reject) => {
-            var request   = new Request;
-            request.Class = DaemonRequest.GET;
-            request.Cid   = cid;
-            request.Path  = path;
+      if (! this.client.write(request.serialize())) {
+        reject("Failed to write request to TCP connection");
+      }
 
-            if (! this.client.write(request.serialize())) {
-                console.log("Failed to write request to TCP connection");
-                reject("Failed to write request to TCP connection");
-            }
+      this.client.on('data', (data) => {
+        let response = this.parseResponse(data);
+        resolve(response.Msg);
+      });
 
-            this.client.on('data', (data) => {
-                var response = this.parseResponse(data);
-                console.log(`Class: ${response.Class}`);
-                console.log(`Msg:   ${response.Msg}`);
-                resolve(response.Msg);
-                this.exit();
-            });
+      this.client.on('error', (err) => {
+        reject(err);
+      });
+    })
+  }
 
-            this.client.on('error', (err) => {
-                console.log(`Error: ${err}`);
-                reject(err);
-                this.exit();
-            })
-        })
-    }
-
-    private parseResponse(data: any): Response {
-        var dataStr: string = data.toString();
-        console.log(`Response received: ${dataStr}`);
-        return new Response().deserialize(dataStr);
-    }
+  private parseResponse(data: any): Response {
+    var dataStr: string = data.toString();
+    return new Response().deserialize(dataStr);
+  }
 };

--- a/src/main/ipfs/ipfs.ts
+++ b/src/main/ipfs/ipfs.ts
@@ -1,0 +1,133 @@
+import { Request } from "./request_json"
+import { Response } from "./response_json";
+import * as net from 'net'
+import { DaemonRequest } from "./classes";
+
+class IPFS {
+    HOST: string = 'localhost';
+    PORT: number = 7777;
+    
+    client: net.Socket;
+
+    constructor() {
+        this.client = new net.Socket();
+        this.init();
+    }
+
+    private init() {
+        this.client.connect(this.PORT, this.HOST, () => {
+            console.log(`Connected to daemon (${this.HOST}:${this.PORT})`);
+        })
+
+        this.client.on('end', () => {
+            console.log("Disconnected from daemon");
+        })
+    }
+
+    /*
+     * Manually exit the connection with the daemon.
+     */
+    exit() {
+        this.client.end();
+    }
+
+    /*
+     * ping the daemon. Mainly used for testing or verifying that the daemon is
+     * running. Returns whether the ping was correctly received.
+     */
+    ping() {
+        return new Promise((resolve, reject) => {
+            var request   = new Request;
+            request.Class = DaemonRequest.PING;
+    
+            if (! this.client.write(request.serialize())) {
+                console.log("Failed to write request to TCP connection");
+                reject("Failed to write request to TCP connection");
+            }
+
+            this.client.on('data', (data) => {
+                var response = this.parseResponse(data);
+
+                console.log(`Class: ${response.Class}`);
+                console.log(`Msg:   ${response.Msg}`);
+
+                resolve(true);
+            })
+
+            this.client.on('error', (err) => {
+                console.log(`Error: ${err}`);
+                reject(err);
+            })
+        });
+    }
+
+    /*
+     * add a file or directory to IPFS. The string returned on success is the
+     * CID of the added content.
+     */
+    add(path: string) {
+        return new Promise((resolve, reject) => {
+            var request   = new Request;
+            request.Class = DaemonRequest.ADD;
+            request.Path  = path;
+
+            if (! this.client.write(request.serialize())) {
+                console.log("Failed to write request to TCP connection");
+                reject("Failed to write request to TCP connection");
+            }
+
+            this.client.on('data', (data) => {
+                var response = this.parseResponse(data);
+                console.log(`Class: ${response.Class}`);
+                console.log(`Msg:   ${response.Msg}`);
+                resolve(response.Msg);
+                this.exit();
+            });
+
+            this.client.on('error', (err) => {
+                console.log(`Error: ${err}`);
+                reject(err);
+                this.exit();
+            });
+        })
+    }
+
+    /*
+     * Get a piece of content from IPFS. Given the CID to fetch and the path to
+     * the directory to save the content into, the daemon will interact with
+     * IPFS and download as needed. Returned will be the path to the content
+     */
+    get(cid: string, path: string) {
+        return new Promise((resolve, reject) => {
+            var request   = new Request;
+            request.Class = DaemonRequest.GET;
+            request.Cid   = cid;
+            request.Path  = path;
+
+            if (! this.client.write(request.serialize())) {
+                console.log("Failed to write request to TCP connection");
+                reject("Failed to write request to TCP connection");
+            }
+
+            this.client.on('data', (data) => {
+                var response = this.parseResponse(data);
+                console.log(`Class: ${response.Class}`);
+                console.log(`Msg:   ${response.Msg}`);
+                resolve(response.Msg);
+                this.exit();
+            });
+
+            this.client.on('error', (err) => {
+                console.log(`Error: ${err}`);
+                reject(err);
+                this.exit();
+            })
+        })
+    }
+
+    private parseResponse(data: any): Response {
+        var dataStr: string = data.toString();
+        console.log(`Response received: ${dataStr}`);
+        return new Response().deserialize(dataStr);
+    }
+};

--- a/src/main/ipfs/request_json.ts
+++ b/src/main/ipfs/request_json.ts
@@ -3,19 +3,21 @@ import Serializable from './serializable';
 
 export default class Request implements Serializable<Request> {
   Class = DaemonRequest.PING;
-  Cid   = "";
-  Path  = "";
+
+  Cid = '';
+
+  Path = '';
 
   serialize(): string {
     return JSON.stringify(this);
   }
 
   deserialize(input: string): Request {
-    var data = JSON.parse(input);
+    const data = JSON.parse(input);
 
     this.Class = data.Class;
-    this.Cid   = data.Cid;
-    this.Path  = data.Path;
+    this.Cid = data.Cid;
+    this.Path = data.Path;
 
     return this;
   }

--- a/src/main/ipfs/request_json.ts
+++ b/src/main/ipfs/request_json.ts
@@ -1,0 +1,22 @@
+import { DaemonRequest } from "./classes";
+import { Serializable } from "./serializable";
+
+export class Request implements Serializable<Request> {
+    Class = DaemonRequest.PING;
+    Cid   = "";
+    Path  = "";
+
+    serialize(): string {
+        return JSON.stringify(this)
+    }
+
+    deserialize(input: string): Request {
+        var data = JSON.parse(input);
+        
+        this.Class = data.Class;
+        this.Cid   = data.Cid;
+        this.Path  = data.Path;
+
+        return this;
+    }
+}

--- a/src/main/ipfs/request_json.ts
+++ b/src/main/ipfs/request_json.ts
@@ -1,22 +1,22 @@
-import { DaemonRequest } from "./classes";
-import { Serializable } from "./serializable";
+import DaemonRequest from './classes';
+import Serializable from './serializable';
 
-export class Request implements Serializable<Request> {
-    Class = DaemonRequest.PING;
-    Cid   = "";
-    Path  = "";
+export default class Request implements Serializable<Request> {
+  Class = DaemonRequest.PING;
+  Cid   = "";
+  Path  = "";
 
-    serialize(): string {
-        return JSON.stringify(this)
-    }
+  serialize(): string {
+    return JSON.stringify(this);
+  }
 
-    deserialize(input: string): Request {
-        var data = JSON.parse(input);
-        
-        this.Class = data.Class;
-        this.Cid   = data.Cid;
-        this.Path  = data.Path;
+  deserialize(input: string): Request {
+    var data = JSON.parse(input);
 
-        return this;
-    }
+    this.Class = data.Class;
+    this.Cid   = data.Cid;
+    this.Path  = data.Path;
+
+    return this;
+  }
 }

--- a/src/main/ipfs/response_json.ts
+++ b/src/main/ipfs/response_json.ts
@@ -3,17 +3,18 @@ import Serializable from './serializable';
 
 export default class Response implements Serializable<Response> {
   Class = DaemonRequest.PING;
-  Msg   = "";
+
+  Msg = '';
 
   serialize(): string {
     return JSON.stringify(this);
   }
 
   deserialize(input: string): Response {
-    var data = JSON.parse(input);
+    const data = JSON.parse(input);
 
     this.Class = data.Class;
-    this.Msg   = data.Msg;
+    this.Msg = data.Msg;
 
     return this;
   }

--- a/src/main/ipfs/response_json.ts
+++ b/src/main/ipfs/response_json.ts
@@ -1,20 +1,20 @@
-import { DaemonRequest } from "./classes";
-import { Serializable } from "./serializable";
+import DaemonRequest from './classes';
+import Serializable from './serializable';
 
-export class Response implements Serializable<Response> {
-    Class = DaemonRequest.PING;
-    Msg   = "";
+export default class Response implements Serializable<Response> {
+  Class = DaemonRequest.PING;
+  Msg   = "";
 
-    serialize(): string {
-        return JSON.stringify(this)
-    }
+  serialize(): string {
+    return JSON.stringify(this);
+  }
 
-    deserialize(input: string): Response {
-        var data = JSON.parse(input);
-        
-        this.Class = data.Class;
-        this.Msg   = data.Msg;
+  deserialize(input: string): Response {
+    var data = JSON.parse(input);
 
-        return this;
-    }
+    this.Class = data.Class;
+    this.Msg   = data.Msg;
+
+    return this;
+  }
 }

--- a/src/main/ipfs/response_json.ts
+++ b/src/main/ipfs/response_json.ts
@@ -1,0 +1,20 @@
+import { DaemonRequest } from "./classes";
+import { Serializable } from "./serializable";
+
+export class Response implements Serializable<Response> {
+    Class = DaemonRequest.PING;
+    Msg   = "";
+
+    serialize(): string {
+        return JSON.stringify(this)
+    }
+
+    deserialize(input: string): Response {
+        var data = JSON.parse(input);
+        
+        this.Class = data.Class;
+        this.Msg   = data.Msg;
+
+        return this;
+    }
+}

--- a/src/main/ipfs/serializable.ts
+++ b/src/main/ipfs/serializable.ts
@@ -1,0 +1,4 @@
+export interface Serializable<T> {
+    serialize(input: T): string;
+    deserialize(input: string): T;
+}

--- a/src/main/ipfs/serializable.ts
+++ b/src/main/ipfs/serializable.ts
@@ -1,4 +1,4 @@
-export interface Serializable<T> {
-    serialize(input: T): string;
-    deserialize(input: string): T;
+export default interface Serializable<T> {
+  serialize(input: T): string;
+  deserialize(input: string): T;
 }

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,7 +4,9 @@ import {
   shell,
   BrowserWindow,
   MenuItemConstructorOptions,
+  dialog,
 } from 'electron';
+import { addIPFS, getIPFS, pingIPFS } from './ipfs/ipfs';
 
 interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string;
@@ -251,6 +253,87 @@ export default class MenuBuilder {
                   },
                 },
               ],
+      },
+      {
+        label: 'IPFS',
+        submenu: [
+          {
+            label: 'Ping',
+            click: () => {
+              pingIPFS()
+                .then((res) => {
+                  return dialog.showMessageBox(this.mainWindow, {
+                    message: `IPFS Ping Result: ${res ? 'Success' : 'Fail'}`,
+                    type: 'info',
+                    title: 'IPFS Ping',
+                  });
+                })
+                .catch((err) => {
+                  return dialog.showErrorBox(
+                    'IPFS Add Error',
+                    `Confirm that the IPFS daemon is running.\n${err}`
+                  );
+                });
+            },
+          },
+          {
+            label: 'Add',
+            click: () => {
+              dialog
+                .showOpenDialog(this.mainWindow, {
+                  properties: ['openFile'],
+                })
+                .then((choice) => {
+                  return choice.canceled
+                    ? Promise.reject()
+                    : addIPFS(choice.filePaths[0]);
+                })
+                .then((res) => {
+                  return dialog.showMessageBox(this.mainWindow, {
+                    message: `IPFS added file with CID ${res}`,
+                    type: 'info',
+                    title: 'IPFS Add',
+                  });
+                })
+                .catch((err) => {
+                  return dialog.showErrorBox(
+                    'IPFS Add Error',
+                    `Confirm that the IPFS daemon is running.\n${err}`
+                  );
+                });
+            },
+          },
+          {
+            label: 'Get',
+            click: () => {
+              dialog
+                .showOpenDialog(this.mainWindow, {
+                  properties: ['openDirectory'],
+                })
+                .then((choice) => {
+                  return choice.canceled
+                    ? Promise.reject()
+                    : getIPFS(
+                        'QmUaoioqU7bxezBQZkUcgcSyokatMY71sxsALxQmRRrHrj',
+                        choice.filePaths[0]
+                      );
+                })
+                .then((res) => {
+                  return dialog.showMessageBox(this.mainWindow, {
+                    message: `Downloaded content from IFPS. Saved as: ${res}`,
+                    type: 'info',
+                    title: 'IPFS Get',
+                  });
+                })
+                .catch((err) => {
+                  return dialog.showErrorBox(
+                    'IPFS Get Error',
+                    `Confirm that the IPFS daemon is running.\n${err}`
+                  );
+                });
+            },
+          },
+        ],
       },
       {
         label: 'Help',


### PR DESCRIPTION
Add a basic setup for issuing requests to the IPFS daemon. Includes methods for directly pinging, adding, and getting.

Addresses part of issue #6 